### PR TITLE
Interface changes

### DIFF
--- a/src/pathwayvis/components/map/map.component.ts
+++ b/src/pathwayvis/components/map/map.component.ts
@@ -196,8 +196,9 @@ class MapComponentCtrl {
         });
 
         this._q.all([modelPromise, infoPromise]).then((responses: any) => {
-            this._mapOptions.setModel(responses[0].data['response'][selectedItem.phase].model, responses[0].data['response']['model-id'], id);
-            this._mapOptions.setReactionData(responses[0].data['response'][selectedItem.phase].fluxes, id);
+            let modelResponse = responses[0].data['response'][selectedItem.phase];
+            this._mapOptions.setModel(modelResponse.model, modelResponse['modelId'], id);
+            this._mapOptions.setReactionData(modelResponse.fluxes, id);
             this._mapOptions.setMapInfo(responses[1].data['response'][selectedItem.phase], id);
 
             this.shared.loading--;

--- a/src/pathwayvis/components/map/map.component.ts
+++ b/src/pathwayvis/components/map/map.component.ts
@@ -171,7 +171,6 @@ class MapComponentCtrl {
         let self = this;
         let id_list = this._mapOptions.getMapObjectsIds();
         id_list.forEach(function (id) {
-            console.log(id);
             let selectedItem = self._mapOptions.getMapObject(id).selected;
             self._loadMap(selectedItem, id);
         })
@@ -182,24 +181,24 @@ class MapComponentCtrl {
         this.shared.loading++;
         let settings = this._mapOptions.getMapSettings();
 
-        const modelPromise = this._api.get('data-adjusted/model', {
-            'sample-ids': selectedItem.sample,
-            'phase-id': selectedItem.phase,
+        const modelPromise = this._api.post('data-adjusted/model', {
+            'sampleIds': JSON.parse(selectedItem.sample),
+            'phaseId': JSON.parse(selectedItem.phase),
             'method': selectedItem.method,
             'map': settings.map_id,
-            'with-fluxes': 1,
-            'model-id': settings.model_id
+            'withFluxes': true,
+            'modelId': settings.model_id
         });
 
-        const infoPromise = this._api.get('samples/info', {
-            'sample-ids': selectedItem.sample,
-            'phase-id': selectedItem.phase
+        const infoPromise = this._api.post('samples/info', {
+            'sampleIds': JSON.parse(selectedItem.sample),
+            'phaseId': JSON.parse(selectedItem.phase)
         });
 
         this._q.all([modelPromise, infoPromise]).then((responses: any) => {
-            this._mapOptions.setModel(responses[0].data.model, responses[0].data['model-id'], id);
-            this._mapOptions.setReactionData(responses[0].data.fluxes, id);
-            this._mapOptions.setMapInfo(responses[1].data, id);
+            this._mapOptions.setModel(responses[0].data['response'][selectedItem.phase].model, responses[0].data['response']['model-id'], id);
+            this._mapOptions.setReactionData(responses[0].data['response'][selectedItem.phase].fluxes, id);
+            this._mapOptions.setMapInfo(responses[1].data['response'][selectedItem.phase], id);
 
             this.shared.loading--;
         }, (error) => {

--- a/src/pathwayvis/components/maploader/maploader.component.ts
+++ b/src/pathwayvis/components/maploader/maploader.component.ts
@@ -60,7 +60,7 @@ class MapLoaderComponentCtrl {
                 .then((response: angular.IHttpPromiseCallbackArg<types.Sample[]>) => {
                     // need to set null properties first!
                     this.mapOptions.setExperiment(this.selected.experiment);
-                    this.samples = response.data;
+                    this.samples = response.data['response'];
                     this.selected.sample = null;
                     this.selected.phase = null;
                 });
@@ -90,7 +90,7 @@ class MapLoaderComponentCtrl {
 
             this.mapOptions.getPhases(sample).then((response: angular.IHttpPromiseCallbackArg<types.Phase[]>) => {
                 this.mapOptions.setSample(sample);
-                this.phases = response.data;
+                this.phases = response.data['response'];
                 this.selected.phase = null;
             }, (error) => {
                 this.toastService.showErrorToast('Oops! Sorry, there was a problem loading selected sample.');
@@ -106,7 +106,7 @@ class MapLoaderComponentCtrl {
         let result = "_";
         if(this.phases){
             this.phases.some((item: types.Phase) =>{
-                if(this.selected.phase == item.id){
+                if(this.selected.phase == item.id.toString()){
                     result = item.name;
                     return true
                 }

--- a/src/pathwayvis/pathwayvis.module.js
+++ b/src/pathwayvis/pathwayvis.module.js
@@ -13,6 +13,7 @@ import {ActionsService} from './services/actions/actions.service';
 import DONUT_LARGE from '../../img/icons/donut_large.svg';
 import {DecafAPIProvider} from './providers/decafapi.provider';
 import {ModelAPIProvider} from './providers/modelapi.provider';
+import {ModelWSProvider} from './providers/modelws.provider';
 import {LegendComponent} from './components/legend/legend.component';
 import {SettingsComponent} from './components/settings/settings.component';
 import {InfoComponent} from './components/info/info.component';
@@ -22,6 +23,7 @@ export const PathwayVisModule = angular.module('pathwayvis', [
 	])
 	.provider('decafAPI', DecafAPIProvider)
 	.provider('modelAPI', ModelAPIProvider)
+	.provider('modelWS', ModelWSProvider)
 	.service('api', APIService)
 	.service('ws', WSService)
 	.service('actions', ActionsService)

--- a/src/pathwayvis/providers/decafapi.provider.ts
+++ b/src/pathwayvis/providers/decafapi.provider.ts
@@ -1,5 +1,4 @@
 export class DecafAPIProvider {
-    // host = 'http://localhost:7000';
     host = 'https://api.dd-decaf.eu';
 
     $get() {

--- a/src/pathwayvis/providers/modelws.provider.ts
+++ b/src/pathwayvis/providers/modelws.provider.ts
@@ -1,0 +1,8 @@
+export class ModelWSProvider {
+    host = 'wss://api.dd-decaf.eu';
+    prefix = '/wsmodels';
+
+    $get() {
+        return this.host + this.prefix;
+    }
+}

--- a/src/pathwayvis/services/mapoption.service.ts
+++ b/src/pathwayvis/services/mapoption.service.ts
@@ -53,7 +53,7 @@ export class MapOptionService {
         // this.$scope = $scope;
 
         this.apiService.get('experiments').then((response: angular.IHttpPromiseCallbackArg<types.Experiment[]>) => {
-            this.experiments = response.data;
+            this.experiments = response.data['response'];
         });
 
         this.init();
@@ -193,13 +193,13 @@ export class MapOptionService {
         this.mapObjects[this.selectedMapObjectId].selected.experiment = experiment;
     }
 
-    public setSample(sample: number[]) : void {
+    public setSample(sample: string) : void {
         this.mapObjects[this.selectedMapObjectId].selected.phase = null;
         this.shouldLoadMap = true;
         this.mapObjects[this.selectedMapObjectId].selected.sample = sample;
     }
 
-    public setPhase(phase: number) : void {
+    public setPhase(phase: string) : void {
         this.shouldLoadMap = true;
         this.mapObjects[this.selectedMapObjectId].selected.phase = phase;
     }
@@ -252,18 +252,18 @@ export class MapOptionService {
         }
     }
 
-    public getPhases(sample: number[]) : angular.IPromise<Object> {
+    public getPhases(sample: string) : angular.IPromise<Object> {
         if (sample) {
-            return this.apiService.get('samples/phases', {
-                'sample-ids': sample
+            return this.apiService.post('samples/phases', {
+                'sampleIds': JSON.parse(sample)
             });
         }
     }
 
-    public setModelsFromSample(sample: number[]): void{
+    public setModelsFromSample(sample: string): void{
         this.getModelOptions(sample).then(
             (response: angular.IHttpPromiseCallbackArg<string[]>) => {
-                this.models = response.data;
+                this.models = response.data['response'];
                 this.setSelectedModel(this.models[0]);
             }, (error) => {
                 this.toastService.showErrorToast('Oops! Sorry, there was a problem loading selected sample.');
@@ -274,10 +274,10 @@ export class MapOptionService {
         return this.models;
     }
 
-    public getModelOptions(sample: number[]) : angular.IPromise<Object> {
+    public getModelOptions(sample: string) : angular.IPromise<Object> {
         if (sample) {
-            return this.apiService.get('samples/model-options', {
-                'sample-ids': sample
+            return this.apiService.post('samples/model-options', {
+                'sampleIds': JSON.parse(sample)
             });
         }
     }
@@ -316,8 +316,8 @@ export class MapOptionService {
         let obj = <any> {
             id: id,
             selected: {
-                'map_id' : 'Central metabolism',
-                'model_id' : null,
+                'mapId' : 'Central metabolism',
+                'modelId' : null,
                 'method': this.getDeafultMethod()
             },
             mapData: {

--- a/src/pathwayvis/services/ws.ts
+++ b/src/pathwayvis/services/ws.ts
@@ -1,5 +1,7 @@
 import * as _ from 'lodash';
 import {ToastService} from "./toastservice";
+import {ModelWSProvider} from '../providers/modelws.provider';
+
 
 interface RequestDetails {
     path: string;
@@ -12,9 +14,6 @@ interface Callback {
     data: string;
 }
 
-
-// WS url
-export const WS_ROOT_URL = 'wss://api.dd-decaf.eu/wsmodels/';
 
 export class WSService {
 
@@ -29,6 +28,7 @@ export class WSService {
     private _callbacks: Callback[] = [];
     private _q: angular.IQService;
     private toastService: ToastService;
+    private modelWS: ModelWSProvider;
 
     public onopen: (ev: Event) => void = function (event: Event) {};
     public onclose: (ev: CloseEvent) => void = function (event: CloseEvent) {};
@@ -36,14 +36,16 @@ export class WSService {
     public onmessage: (ev: MessageEvent) => void = function (event: MessageEvent) {};
     public onerror: (ev: ErrorEvent) => void = function (event: ErrorEvent) {};
 
-    constructor($q: angular.IQService, ToastService: ToastService) {
+    constructor($q: angular.IQService, ToastService: ToastService, modelWS: ModelWSProvider) {
         this._q = $q;
         this.toastService = ToastService;
+        this.modelWS = modelWS;
     }
 
     public connect(reconnectAttempt: boolean, path: string) {
         this.readyState = WebSocket.CONNECTING;
-        this._url = WS_ROOT_URL + path;
+
+        this._url = this.modelWS + '/' + path;
 
         this._ws = new WebSocket(this._url);
         this.onconnecting();

--- a/src/pathwayvis/types.ts
+++ b/src/pathwayvis/types.ts
@@ -62,8 +62,8 @@ export interface MapObject{
 
 export interface SelectedItems {
     experiment?: number;
-    sample?: number[];
-    phase?: number;
+    sample?: string;
+    phase?: string;
     method?: string;
     map?: string;
     model?: string;


### PR DESCRIPTION
Due to the Venom transition interface changes were introduced
* lists and maps with arbitrary keys are now in the message of format `{"response": <list or map>}` for the sake of protobuf compatibility in venom framework
* json keys are in camelCase
* Websocket has a provider