### PR TITLE
Chore/cleanup info component

### DIFF
--- a/src/pathwayvis/components/info/info.component.html
+++ b/src/pathwayvis/components/info/info.component.html
@@ -4,9 +4,10 @@
       <md-subheader class="md-primary">Genotype changes</md-subheader>
       <md-list layout-padding>
         <md-list-item ng-repeat="change in ctrl.getGenotypeChanges()">
-          <span class="md-caption" id="genotype"> {{ change | limitTo : 30 }}...
-                    <md-tooltip md-direction="right">{{ change }}</md-tooltip>
-                  </span>
+          <span>
+              <md-tooltip md-direction="left">{{ change }}</md-tooltip>
+              <span class="md-caption"> {{ change | limitTo : 30 }}...</span>
+          </span>
         </md-list-item>
       </md-list>
     </md-content>
@@ -19,8 +20,8 @@
         <table md-table>
           <tbody md-body>
             <tr md-row ng-repeat="change in ctrl.getMeasurements()">
-              <td md-cell>{{ change["name"] }}</td>
-              <td md-cell>{{ change["measurements"].join(', ') }} {{ change["unit"] }} g<sup>-1</sup> h<sup>-1</sup></td>
+              <td md-cell>{{ change.name }}</td>
+              <td md-cell><span>{{ change.measurements.join(', ') }} {{ change.unit }} g<sup>-1</sup> h<sup>-1</sup></span></td>
             </tr>
           </tbody>
         </table>

--- a/src/pathwayvis/components/info/info.component.scss
+++ b/src/pathwayvis/components/info/info.component.scss
@@ -1,7 +1,0 @@
-#genotype{
-	cursor: default;
-}
-
-sup {
-	vertical-align: top !important;
-}

--- a/src/pathwayvis/components/info/info.component.ts
+++ b/src/pathwayvis/components/info/info.component.ts
@@ -1,5 +1,4 @@
 import * as types from '../../types';
-import './info.component.scss';
 import * as template from './info.component.html';
 import { MapOptionService } from "../../services/mapoption.service";
 


### PR DESCRIPTION
Who needs CSS?

Using id is usually bad practice. We're working on a modular system, which should allow the instantiation of the same module twice - using id prevents that. Especially in list!

Property access should use dot notation whenever possible (exceptions: dynamic access, bad naming - space or special character in property name). Single quotes are preferred to double ones.

- [x] Fixed tooltip issue (tooltip was flickering)
- [x] No need to enforce style. `md-cell` has [messed up rule](https://github.com/daniel-nagy/md-data-table/blob/06e1993154664af5e1571e0abb4d28e76790af19/dist/md-data-table.css#L342), enforcing `vertical-align: middle` for direct children Fixed by wrapping the cell content in a `span`.